### PR TITLE
add instruction on readme connection settings with ssl secure

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ void main(List<String> args) async {
     'database': 'banco_teste',
     'username': 'root',
     'password': 'pass',
+    'sslmode': 'require',
     // 'pool': true,
     // 'poolsize': 2,
   });


### PR DESCRIPTION
show newcomers the option to pass 'sslmode': 'secure' if needed. I was testing with a new mysql/ubuntu:
mysql  Ver 8.0.41-0ubuntu0.24.04.1 for Linux on x86_64
and gave me this exception:
![exception when using eloquent_dart package](https://github.com/user-attachments/assets/77ba7f38-c354-43fe-9475-74c1ede18fdf)

The exception says connection expects to be set to true, but I had to dig the code and find out how to set it properly as eloquent_dart expects.